### PR TITLE
feat: add hunk_wrap_file option to wrap hunks across files

### DIFF
--- a/doc/difftastic-nvim.txt
+++ b/doc/difftastic-nvim.txt
@@ -104,8 +104,8 @@ Default keybindings:
     Key         Action ~
     ]f          Next file
     [f          Previous file
-    ]c          Next hunk
-    [c          Previous hunk
+    ]c          Next hunk (see |difftastic-nvim-hunk-wrap-file|)
+    [c          Previous hunk (see |difftastic-nvim-hunk-wrap-file|)
     <Tab>       Toggle focus between file tree and diff panes
     <CR>        Select file or toggle directory (in tree)
     q           Close diff view
@@ -122,6 +122,7 @@ Call the setup function with your options: >lua
         download = false,       -- Auto-download pre-built binary (default: false)
         vcs = "jj",             -- "jj" (default) or "git"
         highlight_mode = "treesitter", -- "treesitter" (default) or "difftastic"
+        hunk_wrap_file = false, -- Wrap to next/prev file at end/start of hunks
         keymaps = {
             next_file = "]f",
             prev_file = "[f",
@@ -136,8 +137,8 @@ Call the setup function with your options: >lua
             width = 40,
             icons = {
                 enable = true,
-                dir_open = "",
-                dir_closed = "",
+                dir_open = "",
+                dir_closed = "",
             },
         },
         highlights = {
@@ -147,6 +148,7 @@ Call the setup function with your options: >lua
     })
 <
 All options are optional. Only specify what you want to override.
+Set a keymap to `false` to disable it.
 
                                                        *difftastic-nvim-download*
 download ~
@@ -175,13 +177,28 @@ highlight_mode ~
 
     Default: "treesitter"
 
+                                                  *difftastic-nvim-hunk-wrap-file*
+hunk_wrap_file ~
+    When enabled, navigating past the last hunk in a file with `next_hunk`
+    will automatically jump to the first hunk of the next file. Similarly,
+    `prev_hunk` at the first hunk will jump to the last hunk of the previous
+    file.
+
+    When at the last file, `next_hunk` wraps to the first file. When at the
+    first file, `prev_hunk` wraps to the last file.
+
+    This is useful for quickly reviewing all changes across multiple files
+    using a single key (e.g., `<Tab>` for next hunk).
+
+    Default: false
+
                                                         *difftastic-nvim-keymaps*
 Keymap options:
 
     next_file       Jump to next file in the diff
     prev_file       Jump to previous file in the diff
-    next_hunk       Jump to next change hunk within current file
-    prev_hunk       Jump to previous change hunk within current file
+    next_hunk       Jump to next change hunk (wraps to next file if enabled)
+    prev_hunk       Jump to previous change hunk (wraps to prev file if enabled)
     close           Close the diff view
     focus_tree      Move focus to the file tree (from diff panes)
     focus_diff      Move focus to the diff pane (from tree)

--- a/doc/tags
+++ b/doc/tags
@@ -7,6 +7,7 @@ difftastic-nvim-contents	difftastic-nvim.txt	/*difftastic-nvim-contents*
 difftastic-nvim-download	difftastic-nvim.txt	/*difftastic-nvim-download*
 difftastic-nvim-highlight-mode	difftastic-nvim.txt	/*difftastic-nvim-highlight-mode*
 difftastic-nvim-highlights	difftastic-nvim.txt	/*difftastic-nvim-highlights*
+difftastic-nvim-hunk-wrap-file	difftastic-nvim.txt	/*difftastic-nvim-hunk-wrap-file*
 difftastic-nvim-installation	difftastic-nvim.txt	/*difftastic-nvim-installation*
 difftastic-nvim-introduction	difftastic-nvim.txt	/*difftastic-nvim-introduction*
 difftastic-nvim-keybindings	difftastic-nvim.txt	/*difftastic-nvim-keybindings*

--- a/justfile
+++ b/justfile
@@ -20,6 +20,10 @@ lint: fmt-check
 build *args='':
   cargo build --workspace --all $@
 
-# Run tests
+# Run Rust tests
 test *args='':
   cargo nextest run --workspace --all --all-features $@
+
+# Run Lua tests (requires nvim with plenary.nvim installed)
+test-lua:
+  nvim --headless -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal_init.lua'}"

--- a/lua/difftastic-nvim/diff.lua
+++ b/lua/difftastic-nvim/diff.lua
@@ -176,46 +176,72 @@ local function get_diff_win(state)
     return nil
 end
 
---- Jump to the next hunk (wraps to first).
+--- Jump to the next hunk.
 --- @param state table Plugin state
+--- @return boolean True if jumped to a hunk, false if at/past last hunk
 function M.next_hunk(state)
     if #M.hunk_positions == 0 then
-        return
+        return false
     end
     local win = get_diff_win(state)
     if not win then
-        return
+        return false
     end
 
     local line = vim.api.nvim_win_get_cursor(win)[1]
     for _, pos in ipairs(M.hunk_positions) do
         if pos > line then
             vim.api.nvim_win_set_cursor(win, { pos, 0 })
-            return
+            return true
         end
     end
-    vim.api.nvim_win_set_cursor(win, { M.hunk_positions[1], 0 })
+    return false
 end
 
---- Jump to the previous hunk (wraps to last).
+--- Jump to the previous hunk.
 --- @param state table Plugin state
+--- @return boolean True if jumped to a hunk, false if at/before first hunk
 function M.prev_hunk(state)
     if #M.hunk_positions == 0 then
-        return
+        return false
     end
     local win = get_diff_win(state)
     if not win then
-        return
+        return false
     end
 
     local line = vim.api.nvim_win_get_cursor(win)[1]
     for i = #M.hunk_positions, 1, -1 do
         if M.hunk_positions[i] < line then
             vim.api.nvim_win_set_cursor(win, { M.hunk_positions[i], 0 })
-            return
+            return true
         end
     end
-    vim.api.nvim_win_set_cursor(win, { M.hunk_positions[#M.hunk_positions], 0 })
+    return false
+end
+
+--- Jump to the first hunk.
+--- @param state table Plugin state
+function M.first_hunk(state)
+    if #M.hunk_positions == 0 then
+        return
+    end
+    local win = get_diff_win(state)
+    if win then
+        vim.api.nvim_win_set_cursor(win, { M.hunk_positions[1], 0 })
+    end
+end
+
+--- Jump to the last hunk.
+--- @param state table Plugin state
+function M.last_hunk(state)
+    if #M.hunk_positions == 0 then
+        return
+    end
+    local win = get_diff_win(state)
+    if win then
+        vim.api.nvim_win_set_cursor(win, { M.hunk_positions[#M.hunk_positions], 0 })
+    end
 end
 
 return M

--- a/lua/difftastic-nvim/init.lua
+++ b/lua/difftastic-nvim/init.lua
@@ -13,6 +13,8 @@ M.config = {
     vcs = "jj",
     --- Highlight mode: "treesitter" (full syntax) or "difftastic" (no syntax, colored changes only)
     highlight_mode = "treesitter",
+    --- When true, next_hunk at last hunk wraps to next file (and prev_hunk to prev file)
+    hunk_wrap_file = false,
     keymaps = {
         next_file = "]f",
         prev_file = "[f",
@@ -61,8 +63,14 @@ function M.setup(opts)
     if opts.highlight_mode then
         M.config.highlight_mode = opts.highlight_mode
     end
+    if opts.hunk_wrap_file ~= nil then
+        M.config.hunk_wrap_file = opts.hunk_wrap_file
+    end
     if opts.keymaps then
-        M.config.keymaps = vim.tbl_extend("force", M.config.keymaps, opts.keymaps)
+        -- Manual merge to preserve explicit false/nil values (tbl_extend ignores nil)
+        for k, v in pairs(opts.keymaps) do
+            M.config.keymaps[k] = v
+        end
     end
     if opts.tree then
         if opts.tree.icons then
@@ -185,13 +193,51 @@ function M.prev_file()
 end
 
 --- Navigate to the next hunk.
+--- If hunk_wrap_file is enabled and at the last hunk, wraps to the first hunk of the next file.
 function M.next_hunk()
-    diff.next_hunk(M.state)
+    local jumped = diff.next_hunk(M.state)
+    if not jumped and M.config.hunk_wrap_file then
+        local next_idx = tree.next_file_in_display_order(M.state.current_file_idx)
+        if next_idx then
+            M.show_file(next_idx)
+            vim.defer_fn(function()
+                diff.first_hunk(M.state)
+            end, 10)
+        else
+            -- At last file, wrap to first file
+            local first_idx = tree.first_file_in_display_order()
+            if first_idx then
+                M.show_file(first_idx)
+                vim.defer_fn(function()
+                    diff.first_hunk(M.state)
+                end, 10)
+            end
+        end
+    end
 end
 
 --- Navigate to the previous hunk.
+--- If hunk_wrap_file is enabled and at the first hunk, wraps to the last hunk of the previous file.
 function M.prev_hunk()
-    diff.prev_hunk(M.state)
+    local jumped = diff.prev_hunk(M.state)
+    if not jumped and M.config.hunk_wrap_file then
+        local prev_idx = tree.prev_file_in_display_order(M.state.current_file_idx)
+        if prev_idx then
+            M.show_file(prev_idx)
+            vim.defer_fn(function()
+                diff.last_hunk(M.state)
+            end, 10)
+        else
+            -- At first file, wrap to last file
+            local last_idx = tree.last_file_in_display_order()
+            if last_idx then
+                M.show_file(last_idx)
+                vim.defer_fn(function()
+                    diff.last_hunk(M.state)
+                end, 10)
+            end
+        end
+    end
 end
 
 --- Update binary to latest release.

--- a/lua/difftastic-nvim/keymaps.lua
+++ b/lua/difftastic-nvim/keymaps.lua
@@ -8,16 +8,28 @@ local function setup_diff_keymaps(buf, state)
     local difft = require("difftastic-nvim")
     local keys = difft.config.keymaps
 
-    vim.keymap.set("n", keys.next_file, difft.next_file, { buffer = buf })
-    vim.keymap.set("n", keys.prev_file, difft.prev_file, { buffer = buf })
-    vim.keymap.set("n", keys.next_hunk, difft.next_hunk, { buffer = buf })
-    vim.keymap.set("n", keys.prev_hunk, difft.prev_hunk, { buffer = buf })
-    vim.keymap.set("n", keys.close, difft.close, { buffer = buf })
-    vim.keymap.set("n", keys.focus_tree, function()
-        if state.tree_win and vim.api.nvim_win_is_valid(state.tree_win) then
-            vim.api.nvim_set_current_win(state.tree_win)
-        end
-    end, { buffer = buf })
+    if keys.next_file then
+        vim.keymap.set("n", keys.next_file, difft.next_file, { buffer = buf })
+    end
+    if keys.prev_file then
+        vim.keymap.set("n", keys.prev_file, difft.prev_file, { buffer = buf })
+    end
+    if keys.next_hunk then
+        vim.keymap.set("n", keys.next_hunk, difft.next_hunk, { buffer = buf })
+    end
+    if keys.prev_hunk then
+        vim.keymap.set("n", keys.prev_hunk, difft.prev_hunk, { buffer = buf })
+    end
+    if keys.close then
+        vim.keymap.set("n", keys.close, difft.close, { buffer = buf })
+    end
+    if keys.focus_tree then
+        vim.keymap.set("n", keys.focus_tree, function()
+            if state.tree_win and vim.api.nvim_win_is_valid(state.tree_win) then
+                vim.api.nvim_set_current_win(state.tree_win)
+            end
+        end, { buffer = buf })
+    end
 end
 
 --- Set up keymaps for tree buffer.
@@ -27,13 +39,19 @@ local function setup_tree_keymaps(state)
     local keys = difft.config.keymaps
     local buf = state.tree_buf
 
-    vim.keymap.set("n", keys.focus_diff, function()
-        if state.left_win and vim.api.nvim_win_is_valid(state.left_win) then
-            vim.api.nvim_set_current_win(state.left_win)
-        end
-    end, { buffer = buf })
-    vim.keymap.set("n", keys.next_file, difft.next_file, { buffer = buf })
-    vim.keymap.set("n", keys.prev_file, difft.prev_file, { buffer = buf })
+    if keys.focus_diff then
+        vim.keymap.set("n", keys.focus_diff, function()
+            if state.left_win and vim.api.nvim_win_is_valid(state.left_win) then
+                vim.api.nvim_set_current_win(state.left_win)
+            end
+        end, { buffer = buf })
+    end
+    if keys.next_file then
+        vim.keymap.set("n", keys.next_file, difft.next_file, { buffer = buf })
+    end
+    if keys.prev_file then
+        vim.keymap.set("n", keys.prev_file, difft.prev_file, { buffer = buf })
+    end
 end
 
 --- Setup all keymaps for the diff view.

--- a/lua/difftastic-nvim/tree.lua
+++ b/lua/difftastic-nvim/tree.lua
@@ -361,6 +361,12 @@ function M.first_file_in_display_order()
     return files[1]
 end
 
+function M.last_file_in_display_order()
+    if not M.tree then return nil end
+    local files = collect_visible_files(M.tree)
+    return files[#files]
+end
+
 function M.highlight_current(state)
     if not M.tree or not state.tree_buf then return end
 

--- a/tests/diff_spec.lua
+++ b/tests/diff_spec.lua
@@ -1,0 +1,178 @@
+--- Tests for diff.lua hunk navigation functions
+local diff = require("difftastic-nvim.diff")
+
+describe("diff", function()
+    local mock_win
+    local mock_cursor_line
+
+    before_each(function()
+        -- Reset hunk positions
+        diff.hunk_positions = {}
+        mock_cursor_line = 1
+
+        -- Mock vim API
+        mock_win = 1
+        _G.vim = _G.vim or {}
+        _G.vim.api = _G.vim.api or {}
+        _G.vim.api.nvim_get_current_win = function()
+            return mock_win
+        end
+        _G.vim.api.nvim_win_is_valid = function()
+            return true
+        end
+        _G.vim.api.nvim_win_get_cursor = function()
+            return { mock_cursor_line, 0 }
+        end
+        _G.vim.api.nvim_win_set_cursor = function(_, pos)
+            mock_cursor_line = pos[1]
+        end
+    end)
+
+    describe("next_hunk", function()
+        it("returns false when no hunks", function()
+            diff.hunk_positions = {}
+            local state = { left_win = mock_win, right_win = 2 }
+            local result = diff.next_hunk(state)
+            assert.is_false(result)
+        end)
+
+        it("jumps to next hunk when one exists ahead", function()
+            diff.hunk_positions = { 5, 15, 30 }
+            mock_cursor_line = 1
+            local state = { left_win = mock_win, right_win = 2 }
+
+            local result = diff.next_hunk(state)
+
+            assert.is_true(result)
+            assert.equals(5, mock_cursor_line)
+        end)
+
+        it("jumps to second hunk when cursor is on first", function()
+            diff.hunk_positions = { 5, 15, 30 }
+            mock_cursor_line = 5
+            local state = { left_win = mock_win, right_win = 2 }
+
+            local result = diff.next_hunk(state)
+
+            assert.is_true(result)
+            assert.equals(15, mock_cursor_line)
+        end)
+
+        it("returns false when at last hunk", function()
+            diff.hunk_positions = { 5, 15, 30 }
+            mock_cursor_line = 30
+            local state = { left_win = mock_win, right_win = 2 }
+
+            local result = diff.next_hunk(state)
+
+            assert.is_false(result)
+            assert.equals(30, mock_cursor_line) -- cursor unchanged
+        end)
+
+        it("returns false when past all hunks", function()
+            diff.hunk_positions = { 5, 15, 30 }
+            mock_cursor_line = 50
+            local state = { left_win = mock_win, right_win = 2 }
+
+            local result = diff.next_hunk(state)
+
+            assert.is_false(result)
+        end)
+    end)
+
+    describe("prev_hunk", function()
+        it("returns false when no hunks", function()
+            diff.hunk_positions = {}
+            local state = { left_win = mock_win, right_win = 2 }
+            local result = diff.prev_hunk(state)
+            assert.is_false(result)
+        end)
+
+        it("jumps to previous hunk when one exists behind", function()
+            diff.hunk_positions = { 5, 15, 30 }
+            mock_cursor_line = 20
+            local state = { left_win = mock_win, right_win = 2 }
+
+            local result = diff.prev_hunk(state)
+
+            assert.is_true(result)
+            assert.equals(15, mock_cursor_line)
+        end)
+
+        it("jumps to first hunk from second", function()
+            diff.hunk_positions = { 5, 15, 30 }
+            mock_cursor_line = 15
+            local state = { left_win = mock_win, right_win = 2 }
+
+            local result = diff.prev_hunk(state)
+
+            assert.is_true(result)
+            assert.equals(5, mock_cursor_line)
+        end)
+
+        it("returns false when at first hunk", function()
+            diff.hunk_positions = { 5, 15, 30 }
+            mock_cursor_line = 5
+            local state = { left_win = mock_win, right_win = 2 }
+
+            local result = diff.prev_hunk(state)
+
+            assert.is_false(result)
+            assert.equals(5, mock_cursor_line) -- cursor unchanged
+        end)
+
+        it("returns false when before all hunks", function()
+            diff.hunk_positions = { 5, 15, 30 }
+            mock_cursor_line = 1
+            local state = { left_win = mock_win, right_win = 2 }
+
+            local result = diff.prev_hunk(state)
+
+            assert.is_false(result)
+        end)
+    end)
+
+    describe("first_hunk", function()
+        it("does nothing when no hunks", function()
+            diff.hunk_positions = {}
+            mock_cursor_line = 10
+            local state = { left_win = mock_win, right_win = 2 }
+
+            diff.first_hunk(state)
+
+            assert.equals(10, mock_cursor_line) -- unchanged
+        end)
+
+        it("jumps to first hunk", function()
+            diff.hunk_positions = { 5, 15, 30 }
+            mock_cursor_line = 25
+            local state = { left_win = mock_win, right_win = 2 }
+
+            diff.first_hunk(state)
+
+            assert.equals(5, mock_cursor_line)
+        end)
+    end)
+
+    describe("last_hunk", function()
+        it("does nothing when no hunks", function()
+            diff.hunk_positions = {}
+            mock_cursor_line = 10
+            local state = { left_win = mock_win, right_win = 2 }
+
+            diff.last_hunk(state)
+
+            assert.equals(10, mock_cursor_line) -- unchanged
+        end)
+
+        it("jumps to last hunk", function()
+            diff.hunk_positions = { 5, 15, 30 }
+            mock_cursor_line = 1
+            local state = { left_win = mock_win, right_win = 2 }
+
+            diff.last_hunk(state)
+
+            assert.equals(30, mock_cursor_line)
+        end)
+    end)
+end)

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,0 +1,10 @@
+-- Minimal init for running tests
+-- Add plugin to runtime path
+local plugin_root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":h:h")
+vim.opt.rtp:prepend(plugin_root)
+
+-- Try to load plenary if available
+local ok, _ = pcall(require, "plenary")
+if not ok then
+    print("Warning: plenary.nvim not found. Some tests may fail.")
+end


### PR DESCRIPTION
## Summary

- Add `hunk_wrap_file` config option (default: `false`)
- When enabled, navigating past the last hunk jumps to the next file (and vice versa)
- Wraps around from last file to first
- Keymaps can now be disabled by setting them to `nil`