### PR TITLE
Fix diffing Clojure files has no syntax highlighting

### DIFF
--- a/lua/difftastic-nvim/diff.lua
+++ b/lua/difftastic-nvim/diff.lua
@@ -27,6 +27,7 @@ local FILETYPES = {
     YAML = "yaml",
     HTML = "html",
     CSS = "css",
+    Clojure = "clojure",
 }
 
 --- Set buffer options for diff buffers.


### PR DESCRIPTION
Thanks so much for bringing Difftastic to Neovim! I mainly work in Clojure so this PR sets up the diff buffers filetypes for Clojure.