### PR TITLE
Adjust full-line highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ The `highlight_mode` option controls how syntax highlighting is applied:
 
 ## Highlight Groups
 
-Highlights automatically inherit from your colorscheme's semantic groups (`Added`, `Removed`, `Directory`, `Normal`) and update when you switch themes. Background colors are derived by blending the foreground color with your `Normal` background at 25% opacity.
+Highlights automatically inherit from your colorscheme's semantic groups (`Added`, `Removed`, `Directory`, `Normal`) and update when you switch themes. Background colors are derived by blending the foreground color with your `Normal` background at 30% opacity.
 
 **Treesitter mode** (background colors):
 
@@ -216,10 +216,8 @@ Highlights automatically inherit from your colorscheme's semantic groups (`Added
 
 | Group | Default | Description |
 |-------|---------|-------------|
-| `DifftAddedFg` | Links to `Added` | Added text |
-| `DifftRemovedFg` | Links to `Removed` | Removed text |
-| `DifftAddedInlineFg` | `Added` + bold | Inline added text |
-| `DifftRemovedInlineFg` | `Removed` + bold | Inline removed text |
+| `DifftAddedFg` | `Added` + bold | Added text |
+| `DifftRemovedFg` | `Removed` + bold | Removed text |
 
 **Tree**:
 

--- a/doc/difftastic-nvim.txt
+++ b/doc/difftastic-nvim.txt
@@ -281,7 +281,7 @@ Tree options:
 Highlights automatically inherit from your colorscheme's semantic groups
 (`Added`, `Removed`, `Directory`, `Normal`) and update when you switch
 themes. Background colors are derived by blending the foreground color
-with your `Normal` background at 25% opacity.
+with your `Normal` background at 30% opacity.
 
 Treesitter mode (background colors):
     Group                 Default                 Description ~
@@ -289,10 +289,8 @@ Treesitter mode (background colors):
     DifftRemoved          Derived from `Removed`  Removed lines background
 
 Difftastic mode (foreground colors):
-    DifftAddedFg          Links to `Added`        Added text
-    DifftRemovedFg        Links to `Removed`      Removed text
-    DifftAddedInlineFg    `Added` + bold          Inline added text
-    DifftRemovedInlineFg  `Removed` + bold        Inline removed text
+    DifftAddedFg    `Added` + bold          Added text
+    DifftRemovedFg  `Removed` + bold        Removed text
 
 Tree highlights:
     DifftDirectory        Links to `Directory`    Directory names

--- a/lua/difftastic-nvim/diff.lua
+++ b/lua/difftastic-nvim/diff.lua
@@ -137,25 +137,21 @@ function M.render(state, file)
     vim.api.nvim_buf_clear_namespace(state.right_buf, right_ns, 0, -1)
 
     -- Choose highlight groups based on mode
-    -- treesitter mode: background colors (same for full line and inline)
-    -- difftastic mode: foreground colors (like CLI, bold for inline)
+    -- treesitter mode: background colors
+    -- difftastic mode: foreground colors (like CLI, bold)
     local removed_hl = use_treesitter and "DifftRemoved" or "DifftRemovedFg"
-    local removed_inline_hl = use_treesitter and "DifftRemoved" or "DifftRemovedInlineFg"
     local added_hl = use_treesitter and "DifftAdded" or "DifftAddedFg"
-    local added_inline_hl = use_treesitter and "DifftAdded" or "DifftAddedInlineFg"
 
     -- Apply diff highlights (additions/removals)
     for i, row in ipairs(rows) do
         local line = i - 1
 
         for _, hl in ipairs(row.left.highlights) do
-            local group = hl["end"] == -1 and removed_hl or removed_inline_hl
-            vim.api.nvim_buf_add_highlight(state.left_buf, left_ns, group, line, hl.start, hl["end"])
+            vim.api.nvim_buf_add_highlight(state.left_buf, left_ns, removed_hl, line, hl.start, hl["end"])
         end
 
         for _, hl in ipairs(row.right.highlights) do
-            local group = hl["end"] == -1 and added_hl or added_inline_hl
-            vim.api.nvim_buf_add_highlight(state.right_buf, right_ns, group, line, hl.start, hl["end"])
+            vim.api.nvim_buf_add_highlight(state.right_buf, right_ns, added_hl, line, hl.start, hl["end"])
         end
 
         if row.left.is_filler then

--- a/lua/difftastic-nvim/highlight.lua
+++ b/lua/difftastic-nvim/highlight.lua
@@ -2,7 +2,7 @@
 local M = {}
 
 --- Default opacity for background highlights (0-1)
-M.bg_opacity = 0.25
+M.bg_opacity = 0.3
 
 --- Blend two colors with a given alpha.
 --- @param fg string Foreground hex color (e.g., "#ff0000")
@@ -49,10 +49,6 @@ end
 --- Linked highlight definitions (inherit from colorscheme)
 --- @type table<string, vim.api.keyset.highlight>
 M.linked = {
-    -- Foreground highlights (link to semantic groups)
-    DifftAddedFg = { link = "Added" },
-    DifftRemovedFg = { link = "Removed" },
-
     -- Tree highlights
     DifftFileAdded = { link = "Added" },
     DifftFileDeleted = { link = "Removed" },
@@ -94,8 +90,8 @@ local function apply_highlights(overrides)
         DifftPickerPreviewHover = { bg = normal_blend, bold = true },
         DifftPickerJjDesc = { fg = normal_fg },
         -- Foreground highlights
-        DifftAddedInlineFg = { fg = added_fg, bold = true },
-        DifftRemovedInlineFg = { fg = removed_fg, bold = true },
+        DifftAddedFg = { fg = added_fg, bold = true },
+        DifftRemovedFg = { fg = removed_fg, bold = true },
         DifftFiller = { fg = normal_blend },
     }
 

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -49,17 +49,6 @@ pub struct HighlightRegion {
 }
 
 impl HighlightRegion {
-    /// Creates a highlight region that spans the entire line.
-    ///
-    /// This is used for lines that are entirely new (additions) or
-    /// entirely removed (deletions), where highlighting the full line
-    /// provides better visual feedback than highlighting specific ranges.
-    #[inline]
-    #[must_use]
-    fn full_line() -> Self {
-        Self { start: 0, end: -1 }
-    }
-
     /// Creates a highlight region for a specific column range.
     #[inline]
     #[must_use]
@@ -123,11 +112,8 @@ impl Side {
     #[inline]
     #[must_use]
     fn with_full_highlight(content: String) -> Self {
-        Self::new(
-            content,
-            false,
-            smallvec::smallvec![HighlightRegion::full_line()],
-        )
+        let hl = non_whitespace_span(&content);
+        Self::new(content, false, smallvec::smallvec![hl])
     }
 }
 
@@ -403,10 +389,10 @@ fn compute_highlights(content: &str, changes: &[Change]) -> Highlights {
         return Highlights::new();
     }
 
-    // If a single change covers the entire line, use full-line highlight
+    // If a single change covers the entire line, highlight from first to last non-whitespace
     let len = content.len() as u32;
     if changes.len() == 1 && changes[0].start == 0 && changes[0].end >= len {
-        return smallvec::smallvec![HighlightRegion::full_line()];
+        return smallvec::smallvec![non_whitespace_span(content)];
     }
 
     // Sort and merge adjacent regions (merging across whitespace gaps)
@@ -414,9 +400,9 @@ fn compute_highlights(content: &str, changes: &[Change]) -> Highlights {
     regions.sort_unstable_by_key(|r| r.0);
     let merged = merge_regions(&regions, content.as_bytes());
 
-    // If merged regions cover all non-whitespace, use full-line highlight
+    // If merged regions cover all non-whitespace, highlight from first to last non-whitespace
     if covers_all_non_whitespace(content, &merged) {
-        return smallvec::smallvec![HighlightRegion::full_line()];
+        return smallvec::smallvec![non_whitespace_span(content)];
     }
 
     // Return the individual regions
@@ -424,6 +410,21 @@ fn compute_highlights(content: &str, changes: &[Change]) -> Highlights {
         .into_iter()
         .map(|(start, end)| HighlightRegion::columns(start, end))
         .collect()
+}
+
+/// Returns a highlight spanning from the first to last non-whitespace character.
+fn non_whitespace_span(content: &str) -> HighlightRegion {
+    let first = content
+        .bytes()
+        .position(|b| !b.is_ascii_whitespace())
+        .unwrap_or(0) as u32;
+    let last = content.len() as u32
+        - content
+            .bytes()
+            .rev()
+            .position(|b| !b.is_ascii_whitespace())
+            .unwrap_or(0) as u32;
+    HighlightRegion::columns(first, last)
 }
 
 /// Merges adjacent change regions, bridging gaps that contain only whitespace.
@@ -715,9 +716,19 @@ mod tests {
     }
 
     #[test]
-    fn highlight_full_coverage_is_full_line() {
+    fn highlight_full_coverage_spans_non_whitespace() {
         let highlights = compute_highlights("hello", &[change(0, 5)]);
-        assert_eq!(highlights[0].end, -1);
+        assert_eq!(highlights.len(), 1);
+        assert_eq!(highlights[0].start, 0);
+        assert_eq!(highlights[0].end, 5);
+    }
+
+    #[test]
+    fn highlight_full_coverage_with_indent() {
+        let highlights = compute_highlights("  hello  ", &[change(0, 9)]);
+        assert_eq!(highlights.len(), 1);
+        assert_eq!(highlights[0].start, 2);
+        assert_eq!(highlights[0].end, 7);
     }
 
     #[test]
@@ -731,7 +742,8 @@ mod tests {
     fn highlight_merges_across_whitespace() {
         let highlights = compute_highlights("foo bar", &[change(0, 3), change(4, 7)]);
         assert_eq!(highlights.len(), 1);
-        assert_eq!(highlights[0].end, -1); // merged to full line
+        assert_eq!(highlights[0].start, 0);
+        assert_eq!(highlights[0].end, 7); // merged to span all non-whitespace
     }
 
     #[test]


### PR DESCRIPTION
## Overview

Adjusts the highlighting of full-line changes to only highlight the region between the first non-whitespace character and the last non-whitespace character, rather than the full line up to the last non-whitespace character.