### PR TITLE
feat(diff): infer treesitter filetype highlights from filename

### DIFF
--- a/lua/difftastic-nvim/diff.lua
+++ b/lua/difftastic-nvim/diff.lua
@@ -124,7 +124,7 @@ function M.render(state, file)
     -- Apply syntax highlighting based on mode
     local use_treesitter = config.highlight_mode ~= "difftastic"
     if use_treesitter then
-        local ft = FILETYPES[file.language]
+        local ft = FILETYPES[file.language] or vim.filetype.match({ filename = vim.fn.fnamemodify(file.path, ":t"), })
         if ft then
             ensure_treesitter(state.left_buf, ft)
             ensure_treesitter(state.right_buf, ft)


### PR DESCRIPTION
# PR Description

This PR infers the filetype from the corresponding file's path. That is,

- `diff.lua` `M.render()` function takes in `file` as a parameter (lua table).
- This `file` parameter is from difftastic's (via the lib) JSON output, which is a list of files with the following properties:
  - `file.additions`;
  - `file.aligned_Lines`;
  - `file.language`;
  > This is what we currently use for setting file types where we lookup a const table.
  - `file.path`;
  > This is the path which contains the filename including the extension vim can use to infer filetypes.
  - ...
- When the lookup fails, we use filename from `file.path` to infer the filetype via `vim.filetype.match`.
- Pass this to `ensure_treesitter`  like before.

More tangibly, without modifying the lookup table
Before:
<img width="1751" height="1259" alt="image" src="https://github.com/user-attachments/assets/d57f8521-9838-46d8-857c-c5a3bacb8403" />

After:
<img width="1747" height="1215" alt="image" src="https://github.com/user-attachments/assets/4d3b6618-76ce-4a4a-810b-1de812da8139" />

# Related Issues
This may essentially close #16 for filetypes that aren't yet handled.